### PR TITLE
Adding detailed trainers guide for 2day f2f workshop

### DIFF
--- a/trainer-guide-2-day.md
+++ b/trainer-guide-2-day.md
@@ -1,6 +1,6 @@
 ---
 layout: page
-subtitle: Sample workshop guide for trainers
+subtitle: 2-day face-to-face Instructor Training guide for Trainers
 ---
 
 This is a detailed trainer's guide for running a two-day intense face-to-face Instructor Training workshop. The guide should allow the trainers plan and deliver the workshop but it is not a strict schedule. The trainers should allow for some flexibility and adapting to the local circumstances.

--- a/trainer-guide-2-day.md
+++ b/trainer-guide-2-day.md
@@ -5,56 +5,88 @@ subtitle: 2-day face-to-face Instructor Training guide for Trainers
 
 This is a detailed trainer's guide for running a two-day intense face-to-face Instructor Training workshop. The guide should allow the trainers plan and deliver the workshop but it is not a strict schedule. The trainers should allow for some flexibility and adapting to the local circumstances.
 
+## Theming exercises Day 1
+On the first day of the training you will ask the trainee instructors to complete a series of exercises. Theming these exercises (so providing some guidelines on the topics) helps trainees be more focused and complete the exercises on time. It will also provide a nice thread throughout the day.
+
+The idea for Day 1 is to build exercises around "the coolest thing in your research / work".
+
+* Multiple Choice Question: design an MCQ about the coolest thing in your research/work OR choose a topic that would be introduced in the first undergrad year in your domain (possibly try to design a question which can be assessed by your partner at the IT). If you absolutely cannot come up with such question, then pick a topic from the SWC/DC curriculum.
+* Concept map: 
+* First recorded teaching (video) exercise: 
+
 
 ## Proposed schedule
 
 A typical schedule for a two-day course is:
 
 *   Day 1
-    *   09:00 Welcome and introductions (15 min)
-    *   09:15 Key definitions, concepts and teaching goals (15 min)
-    *   09:30 Mental models. Novices and misconceptions (10 min)
-    *   09:40 Formative and summative assessment (15 min)
-    *   09:55 Multiple Choice Questions as formative assessment (15 min)
-    *   10:10 EXERCISE 1 Designing own MCQ and exchanging with the partner (20 min)
-    *   10:30 Coffee break  (allow for finishing the exercise and networking)
-    *   11:00 Review of the formative assessment exercise (15 min)
-    *   11:15 Teaching as performance art (15 min)
-    *   11:30 EXERCISE 2 Recorded teaching
-    *   12:00 Lunch (allow for finishing off the exercise) / minute cards
-    *   13:00 Mental models and experts (10 min)
-    *   13:10 Concept maps 7 +/- 2. Concept map example (20 min)
-    *   13:30 EXERCISE 3 Develop concept map and share with partner (20 min)
-    *   13:50 Review of the concept map exercise (20 min)
-    *   14:10 Cognitive load theory (15 min)
-    *   14:25 Faded examples (10 min)
-    *   14:30 EXERCISE 4 Develop a faded example (45 min, including coffee break)
-    *   14:30 Coffee break
-    *   15:15 Review of the faded examples exercise (15 min)
-    *   15:30 Reverse instructional design (RID); Bloom's taxonomy; learning outcomes (15 min)
-    *   15:45 EXERCISE 5 Critique and rewrite learning outcomes (15 min)
-    *   16:15 Review of the exercise with learning outcomes (15 min)
-    *   16:30 EXERCISE 6 Recorded teaching based on concept map with 2x2 rubric and RID/ learning outcomes
-    *   16:50 Discuss overnight homework (read operations guide, complete Teaching Perspectives Inventory)
-    *   17:00: Minute cards for the afternoon session and close
+    *   **09:00 Welcome and introductions (15 min)**
+    *   **09:15 [Key definitions, concepts and teaching goals](http://swcarpentry.github.io/instructor-training/01-introduction.html) (15 min)**  <br/>
+        *Concepts: Educational psychology; Instructional design; Pedagogical Content Knowledge. Teacher's enthusiasm. <br/>
+        Goal: understand effective approaches and methods for teaching.<br/>
+        Ask trainees: memorable moment from a class you took or taught.*        
+    *   **09:30 [Mental models. Novices and misconceptions](http://swcarpentry.github.io/instructor-training/02-models.html) (10 min)**         
+    *   **09:40 [Formative and summative assessment](http://swcarpentry.github.io/instructor-training/02-models.html) (15 min)**
+    *   **09:55 Multiple Choice Questions as formative assessment (15 min)** <br/>
+        *Show example with addition. <br/>
+        Explain value of sensible diagnostic answers (lame distractors are bad and are not funny).*    
+    *   **10:10 EXERCISE 1 Designing own MCQ and exchanging with the partner (20 min)**
+    *   **10:30 Coffee break  (allow for finishing the exercise and networking)**
+    *   **11:00 Review of the formative assessment exercise (15 min)** <br/>
+        *Pick a few MCQs in the Etherpad and discuss which are checking the mental model and which are testing for factual knowledge. Explain the difference.*
+    *   **11:15 [Teaching as performance art](http://swcarpentry.github.io/instructor-training/08-performance.html) (15 min)** <br/>
+        *Show one of the SciPy workshop videos.<br/> 
+        Provide feedback on it using the 2x2 grid. Trainer puts in a couple of comments demonstrating difference between contents and delivery. <br/>*
+    *   **11:30 EXERCISE 2 Recorded teaching** <br/>
+        *In groups of 3. <br/>
+        Introduce yourself and talk about the coolest thing in your research/work. <br/>
+        2 minutes<br/>
+        Use the 2x2 grid and put feedback in the Etherpad.*
+    *   **12:00 Lunch (allow for finishing off the exercise) / minute cards**
+    *   **13:00 [Mental models and experts](http://swcarpentry.github.io/instructor-training/03-maps.html) (10 min)**
+    *   **13:10 [Concept maps 7 +/- 2.](http://swcarpentry.github.io/instructor-training/03-maps.html) Concept map example (20 min)**
+    *   **13:30 EXERCISE 3 Develop concept map and share with partner (20 min)** <br/>
+        *Concept map on the topic you introduced in your MCQ and video.<br/>
+        Share it with your partner (find a different one!).<br/>* 
+    *   **13:50 Review of the concept map exercise (20 min)** <br/>
+        *Take 3-4 trainees to draw on the whiteboard and explain their concept maps.*    
+    *   **14:10 [Cognitive load theory](http://swcarpentry.github.io/instructor-training/04-faded.html) (15 min)**
+    *   **14:25 [Faded examples](http://swcarpentry.github.io/instructor-training/04-faded.html) (10 min)** <br/>
+        *Show a faded example. Can be from SWC/DC materials.*
+    *   **14:30 EXERCISE 4 Develop a faded example (45 min, including coffee break)** <br/>
+        *Develop a faded example based on your teaching video, MCQ and concept map. <br/>
+        Put them in the Etherpad.*
+    *   **14:30 Coffee break**
+    *   **15:00 Review of the faded examples exercise (10 min)**
+    *   **15:10 [Reverse instructional design (RID)](http://swcarpentry.github.io/instructor-training/05-design.html); [Bloom's taxonomy; learning objectives](http://swcarpentry.github.io/instructor-training/06-objectives.html) (15 min)**
+    *   **15:25 EXERCISE 5 Learning objectives for the topic you presented in the video (15 min)**
+    *   **15:40 Review of the exercise with learning objectives (10 min)**
+    *   **15:50 EXERCISE 6 Recorded teaching based on concept map with 2x2 rubric and RID/ learning objectives (30 min)**
+    *   **16:20 Discuss overnight homework** <br/>
+        *1.Read the [operations guide](http://software-carpentry.org/workshops/operations/) and write down questions in the Etherpad. <br/>
+        2.Complete [Teaching Perspectives Inventory](http://www.teachingperspectives.com/tpi/).<br/>
+        3.Go through one of the SWC/DC lessons and prepare for live coding teaching recording exercise.*
+    *   **16:30: Minute cards for the afternoon session and close**
+    
 *   Day 2
-    *   09:00 Questions based on  Teaching Perspectives Inventory (45 min)
-    *   09:15 Questions based on operations guide (30 min)
-    *   09:45 Live coding demo (30 min)
-    *   10:15 EXERCISE 7 Recorded teaching live coding practice on same lesson (45 min, including coffee)
-    *   10:30 Coffee (and finishing the exercise) 
-    *   11:00 Review of the live coding exercise (20 min)
-    *   11:20 Motivation and demotivation => write your story over lunch
-    *   11:45 EXERCISE 8 Write your story over lunch Minute cards for morning session
-    *   12:00: Lunch (allow for finishing off the exercise) / minute cards
-    *   13:00: Setting up a workshop website - guided discussion (20 min)
-    *   13:20 EXERCISE 9 (in pairs) setting up workshop website (40 min)
-    *   14:00 Discussion of how to tell what effect we're having (20 min)
-    *   14:20 EXERCISE 10 (in groups) develop assessment proposal (arguments for funding) and coffee (40 min)
-    *   14:30 Coffee (and finessing the exercise) 
-    *   15:00 Present assessment proposals (30 min)
-    *   15:30 Overview of lesson materials and how to contribute (45 min)
-    *   16:15 Open discussion
-    *   16:45 Wrap up and minute cards for afternoon session
-    *   17:00 Close
+    *   **09:00 Questions based on  Teaching Perspectives Inventory** (15 min)
+    *   **09:15 Questions based on operations guide (30 min)**
+    *   **09:45 Live coding demo (30 min)**
+    *   **10:15 EXERCISE 7 Recorded teaching live coding practice on lesson prepared as homework (45 min, including coffee)**
+    *   **10:30 Coffee (and finishing the exercise)** 
+    *   **11:00 Review of the live coding exercise ( 15 min)**
+    *   **11:15 [Motivation and demotivation](http://swcarpentry.github.io/instructor-training/07-motivation.html) (15 min)** <br/>
+        *Concepts: indifference and injustice as two major demotivators;
+        impostor syndrome; stereotype threat; SWC/DC Code of Conduct <br/>*
+    *   **11:30 EXERCISE 8 Write your story over lunch. Minute cards for morning session**
+    *   **12:00: Lunch (allow for finishing off the exercise)**
+    *   **13:00: Setting up a workshop website [SWC](https://github.com/swcarpentry/workshop-template) / [DC](https://github.com/datacarpentry/workshop-template) - guided discussion (20 min)**
+    *   **13:20 EXERCISE 9 (in pairs) setting up workshop website (20 min)** <br/>
+        *Preferably split the group so that half does SWC template and half DC template*
+    *   **13:40 Discussion of how to tell what effect we're having (20 min)**
+    *   **14:00 EXERCISE 10 (in groups) develop assessment proposal (arguments for funding) and coffee (30 min)**
+    *   **14:30 Coffee &  Presenting assessment proposals (45 min together with coffee)**
+    *   **15:15 Overview of lesson materials and how to contribute (30 min)**
+    *   **15:45 Open discussion**
+    *   **16:15 Wrap up and minute cards for afternoon session**
 

--- a/trainer-guide-2-day.md
+++ b/trainer-guide-2-day.md
@@ -1,0 +1,60 @@
+---
+layout: page
+subtitle: Sample workshop guide for trainers
+---
+
+This is a detailed trainer's guide for running a two-day intense face-to-face Instructor Training workshop. The guide should allow the trainers plan and deliver the workshop but it is not a strict schedule. The trainers should allow for some flexibility and adapting to the local circumstances.
+
+
+## Proposed schedule
+
+A typical schedule for a two-day course is:
+
+*   Day 1
+    *   09:00 Welcome and introductions (15 min)
+    *   09:15 Key definitions, concepts and teaching goals (15 min)
+    *   09:30 Mental models. Novices and misconceptions (10 min)
+    *   09:40 Formative and summative assessment (15 min)
+    *   09:55 Multiple Choice Questions as formative assessment (15 min)
+    *   10:10 EXERCISE 1 Designing own MCQ and exchanging with the partner (20 min)
+    *   10:30 Coffee break  (allow for finishing the exercise and networking)
+    *   11:00 Review of the formative assessment exercise (15 min)
+    *   11:15 Teaching as performance art (15 min)
+    *   11:30 EXERCISE 2 Recorded teaching
+    *   12:00 Lunch (allow for finishing off the exercise) / minute cards
+    *   13:00 Mental models and experts (10 min)
+    *   13:10 Concept maps 7 +/- 2. Concept map example (20 min)
+    *   13:30 EXERCISE 3 Develop concept map and share with partner (20 min)
+    *   13:50 Review of the concept map exercise (20 min)
+    *   14:10 Cognitive load theory (15 min)
+    *   14:25 Faded examples (10 min)
+    *   14:30 EXERCISE 4 Develop a faded example (45 min, including coffee break)
+    *   14:30 Coffee break
+    *   15:15 Review of the faded examples exercise (15 min)
+    *   15:30 Reverse instructional design (RID); Bloom's taxonomy; learning outcomes (15 min)
+    *   15:45 EXERCISE 5 Critique and rewrite learning outcomes (15 min)
+    *   16:15 Review of the exercise with learning outcomes (15 min)
+    *   16:30 EXERCISE 6 Recorded teaching based on concept map with 2x2 rubric and RID/ learning outcomes
+    *   16:50 Discuss overnight homework (read operations guide, complete Teaching Perspectives Inventory)
+    *   17:00: Minute cards for the afternoon session and close
+*   Day 2
+    *   09:00 Questions based on  Teaching Perspectives Inventory (45 min)
+    *   09:15 Questions based on operations guide (30 min)
+    *   09:45 Live coding demo (30 min)
+    *   10:15 EXERCISE 7 Recorded teaching live coding practice on same lesson (45 min, including coffee)
+    *   10:30 Coffee (and finishing the exercise) 
+    *   11:00 Review of the live coding exercise (20 min)
+    *   11:20 Motivation and demotivation => write your story over lunch
+    *   11:45 EXERCISE 8 Write your story over lunch Minute cards for morning session
+    *   12:00: Lunch (allow for finishing off the exercise) / minute cards
+    *   13:00: Setting up a workshop website - guided discussion (20 min)
+    *   13:20 EXERCISE 9 (in pairs) setting up workshop website (40 min)
+    *   14:00 Discussion of how to tell what effect we're having (20 min)
+    *   14:20 EXERCISE 10 (in groups) develop assessment proposal (arguments for funding) and coffee (40 min)
+    *   14:30 Coffee (and finessing the exercise) 
+    *   15:00 Present assessment proposals (30 min)
+    *   15:30 Overview of lesson materials and how to contribute (45 min)
+    *   16:15 Open discussion
+    *   16:45 Wrap up and minute cards for afternoon session
+    *   17:00 Close
+


### PR DESCRIPTION
This schedule looks very detailed and rigid but should help new trainers work out how to plan the 2day f2f workshop and split the material.

This is only an initial stub. I'd suggest to split trainer's guide as it is now (http://swcarpentry.github.io/instructor-training/instructors.html) into separate guides for different forms of deliver (multi-week online; 2day online and f2f online).