### PR TITLE
10-carpentries: Remind learners that describing and motivating PRs is important

### DIFF
--- a/10-carpentries.md
+++ b/10-carpentries.md
@@ -161,7 +161,21 @@ The final steps in getting certified are as follows:
 1. If you want to teach Software Carpentry, pick one of the core
    lessons and familiarize yourself with the whole thing, then submit
    an exercise for one of its modules as a pull request on GitHub and
-   send the link to your instrutor.
+   send the link to your instrutor. Remember that lesson maintainers
+   will be getting a number of pull requests like this, so take some
+   time to [craft your pitch][what-and-why] so the maintainer
+   understands what you're doing and why you think it's useful. For
+   example:
+
+        04-changes: Add a 'commit --amend' exercise
+
+        Everybody will botch a commit message at some point.  This
+        exercise introduces them to an easy way to fix those mistakes.
+
+   (as both a commit message and a pull-request summary) will be a lot
+   easier for the maintainer than:
+
+        Instructor-training assignment
 
 2. If you want to teach Data Carpentry, pick one of *its* core
    lessons, familiarize yourself with it, and submit an exercise for
@@ -281,4 +295,5 @@ the assessment we do, and how often we do it.
 [swc-operations]: http://software-carpentry.org/workshops/operations.html
 [swc-twitter]: https://twitter.com/swcarpentry
 [swc]: http://software-carpentry.org
+[what-and-why]: https://presentate.com/bobthecow/talks/changing-history#slide-15
 [workshop-template]: https://github.com/swcarpentry/workshop-template

--- a/messages/training-checkout.md
+++ b/messages/training-checkout.md
@@ -2,7 +2,7 @@ Hi everyone,
 
 Thanks again for taking part in Software and Data Carpentry instructor training. In order to wrap up, we would like you to do the following:
 
-1. If you want to teach Software Carpentry, pick one of the core lessons (list at the bottom of this message) and familiarize yourself with the whole thing, then submit an exercise for one of the modules of that lesson as a pull request on GitHub and mail me a link to the PR.
+1. If you want to teach Software Carpentry, pick one of the core lessons (list at the bottom of this message) and familiarize yourself with the whole thing, then submit an exercise for one of the modules of that lesson as a pull request on GitHub and mail me a link to the PR. Remember that lesson maintainers will be getting a number of pull requests like this, so take some time to [craft your pitch][what-and-why] so the maintainer understands what you're doing and why you think it's useful.
 
 2. If you want to teach Data Carpentry, pick one of its core lessons (list at the bottom), familiarize yourself with the whole thing, and submit an exercise for it by going [here][dc-exercises] (which will redirect you to a Google Doc with instructions on format) and mail me to let me know that your exercise is there.
 
@@ -40,3 +40,4 @@ Data Carpentry Core Lessons (from http://www.datacarpentry.org/lessons/):
 
 [dc-exercises]: http://www.datacarpentry.org/instructor-checkout-exercises/
 [etherpad]: http://pad.software-carpentry.org/lesson-discussion-2016
+[what-and-why]: http://swcarpentry.github.io/instructor-training/10-carpentries.html#final-steps


### PR DESCRIPTION
Spun off from [this sub-thread][0].

Try to head off PR and commit-message summaries that don't tell the
lesson maintainer what the change is about, or why the submitter
thinks it's a good idea.

I've put an abbreviated form of this comment in the training-checkout
reminder, with an fully qualified link to more detailed 10-carpentries
entry.  The messages/ entries look like email templates, neither a
relative link (which wouldn't resolve) or a detailed description
(which would be distracting) seem like good fits there.  If the
messages/ entries are email templates, I'd suggest injecting some [YAML
front matter][1] so we can use:

    {{ site.domain }}{{ site.baseurl }}/10-carpentries.html#final-steps

in that link.  But that seemed like a bigger change than I should be
biting off in one commit.

I considered linking our novice Git lesson, which has some wording on
commit messages since swcarpentry/git-novice#78.  Unfortunately, the
summary for that PR is the sort of thing we want to avoid (although
the topic post is great) and there's no link anchor for that part of
the compiled HTML.  The Pope page is also more about the mechanics,
which I consider less on-topic here than Hileman's “pretty pull
requests get merged” (the relevant slides are all of “Lesson 2”.
“Lesson 3” starts on slide 29).  And Hileman links Pope.

[0]: http://lists.software-carpentry.org/pipermail/maintainers_lists.software-carpentry.org/2016-January/000139.html
[1]: http://jekyllrb.com/docs/frontmatter/