### PR TITLE
Temporary fix for CSS used on print

### DIFF
--- a/_sass/common/_03_elements.scss
+++ b/_sass/common/_03_elements.scss
@@ -175,9 +175,13 @@ Use as <p class="person">...</p> or <a href="..." class="person">...</a>
 }
 
 
-
-
 /* GitHub Ribbon */
+@media print {
+    #github-ribbon {
+        display: none;
+    }
+}
+
 #github-ribbon a {
     background: #000;
     color: #fff;

--- a/_sass/foundation-components/_type.scss
+++ b/_sass/foundation-components/_type.scss
@@ -472,10 +472,15 @@ $align-class-breakpoints:
       .print-only { display: none !important; }
       @media print {
         * {
-          background: transparent !important;
           color: $black !important; /* Black prints faster: h5bp.com/s */
           box-shadow: none !important;
           text-shadow: none !important;
+        }
+
+        #navigation,
+        #masthead-no-image-header,
+        .main-footer {
+            display: none;
         }
 
         a,


### PR DESCRIPTION
# Before

![software carpentry_1](https://cloud.githubusercontent.com/assets/1506457/14061692/54a23480-f37e-11e5-9b3a-583544b4f06e.jpg)

![software carpentry_2](https://cloud.githubusercontent.com/assets/1506457/14061693/58a1562e-f37e-11e5-9fb5-ededd8a742d4.jpg)

![software carpentry_3](https://cloud.githubusercontent.com/assets/1506457/14061694/5c1eea5a-f37e-11e5-99b1-f3c260063719.jpg)

# After

![training1](https://cloud.githubusercontent.com/assets/1506457/14061680/165c03e0-f37e-11e5-86ba-1df3545dc1fa.jpg)

![training2](https://cloud.githubusercontent.com/assets/1506457/14061684/1a138f62-f37e-11e5-934f-bce03eab9bce.jpg)

# Details

This remove the header and footer on the print.