### PR TITLE
Add a missing closing parenthesis in Motivation and Demotivation

### DIFF
--- a/_episodes/17-motivation.md
+++ b/_episodes/17-motivation.md
@@ -202,7 +202,7 @@ Depending on whose numbers you trust,
 only 12-18% of programmers are women,
 and those figures have actually been getting worse over the last 20 years.
 There are many reasons for this
-(see Margolis and Fisher's *[Unlocking the Clubhouse][amazon-clubhouse]*,
+(see Margolis and Fisher's *[Unlocking the Clubhouse][amazon-clubhouse]*),
 and for the under-representation of some racial groups:
 in the United States,
 for example,


### PR DESCRIPTION
When refering to Margolis and Fisher, the parenthesis was left open, leaving the reader to think that the under-representation of racial group was actually part of the reference.