### PR TITLE
clarified DC SWC checkout requirements

### DIFF
--- a/_extras/checkout.md
+++ b/_extras/checkout.md
@@ -53,9 +53,8 @@ Trainees must do their work on one of the lessons for which we are currently see
 
 Pick one of the lessons from the list given later in this section
 and submit a *small* change.
-Note that you may submit a change to a Data Carpentry lesson
-when qualifying as a Software Carpentry instructor:
-the goal is to be sure you are familiar with the process.
+
+**Note** that you must submit a change to a Software Carpentry lesson when qualifying as a Software Carpentry instructor. Likewise, you must submit a change to a Data Carpentry lesson when qualifying as a Data Carpentry instructor. Insturctors seeking dual certification should submit two changes, one to each repo. The goal is to be sure you are familiar with the process and the materials.
 
 Your change can be a new exercise or diagram,
 or an improvement to one or more of the lesson's learning objectives.


### PR DESCRIPTION
This change was made in response to @ErinBecker's last comment about being DC or SWC specific for checkout, as described in [PR #216](https://github.com/swcarpentry/instructor-training/pull/216)