### PR TITLE
add standard bootstrap menu icon for small screens

### DIFF
--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -1,6 +1,12 @@
 <nav class="navbar navbar-default">
   <div class="container-fluid">
     <div class="navbar-header">
+      <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#bs-example-navbar-collapse-1" aria-expanded="false">
+        <span class="sr-only">Toggle navigation</span>
+        <span class="icon-bar"></span>
+        <span class="icon-bar"></span>
+        <span class="icon-bar"></span>
+      </button>
       {% if page.carpentry == "swc" %}
       <a href="{{ site.swc_site }}" class="pull-left">
         <img class="navbar-logo" src="{{ site.github.url }}/assets/img/swc-icon-blue.svg" alt="Software Carpentry logo" />


### PR DESCRIPTION
If accepted this pull request will add a "hamburger" menu for small screen devices, fixing https://github.com/swcarpentry/instructor-training/issues/235