### PR TITLE
Fix non-italics word in sentence in italics

### DIFF
--- a/_episodes/08-memory.md
+++ b/_episodes/08-memory.md
@@ -77,8 +77,9 @@ This metaphor helps explain many observed aspects of expert behavior:
     e.g.,
     expert mathematicians' ability to switch effortlessly between algebraic and geometric views of a problem.
 
-    *The local driver probably can use either the names of streets *or* landmarks when giving
-    directions.  The out-of-towner only has street labels.*
+    *The local driver probably can use either the names of streets* 
+    or
+    *landmarks when giving directions.  The out-of-towner only has street labels*.
 
 4.  Finally, this metaphor also explains why experts are better at diagnosis than competent practitioners:
     more linkages between facts makes it easier to reason backward from symptoms to causes.

--- a/_episodes/08-memory.md
+++ b/_episodes/08-memory.md
@@ -79,7 +79,7 @@ This metaphor helps explain many observed aspects of expert behavior:
 
     *The local driver probably can use either the names of streets* 
     or
-    *landmarks when giving directions.  The out-of-towner only has street labels*.
+    *landmarks when giving directions. The out-of-towner only has street labels.*
 
 4.  Finally, this metaphor also explains why experts are better at diagnosis than competent practitioners:
     more linkages between facts makes it easier to reason backward from symptoms to causes.


### PR DESCRIPTION
We had some asterisks in the rendered version. This should fix that.