### PR TITLE
Clarifying 2x2 plot (grid)

### DIFF
--- a/_episodes/19-motivation.md
+++ b/_episodes/19-motivation.md
@@ -94,8 +94,8 @@ learners have a concrete starting point for debugging.
 > **Think** about something you did this week that uses one or more of the skills we teach,
 > (e.g. wrote a function, bulk downloaded data, did some stats in R, forked a repo)
 > and explain how you would use it (or a simplified version of it) as an exercise or example in class.
-> **Pair** up with your neighbor and decide where this exercise fists on a 2x2 plot of "time to master" and "usefulness"?
-> In the class Etherpad, **share** the task and where its fits on the 2x2 plot.
+> **Pair** up with your neighbor and decide where this exercise fists on a 2x2 grid of "short/longtime to master" and "low/high usefulness"?
+> In the class Etherpad, **share** the task and where its fits on the 2x2 grid.
 > As a group, we will discuss how these relate back to our "teach most immediately useful first" approach.
 {: .challenge}
 


### PR DESCRIPTION
what-to-teach.png is not a 2x2 plot. This adds a bit of clarification to the exercise. The alternative is to redraw the plot as a 2x2 grid.