### PR TITLE
Fix missing and spurious references

### DIFF
--- a/_episodes/01-welcome.md
+++ b/_episodes/01-welcome.md
@@ -16,7 +16,7 @@ keypoints:
 
 ## Introductions
 
-> Introductions set the stage for learning.  
+> Introductions set the stage for learning.
 > — Tracy Teal, Executive Director, Data Carpentry
 {: .quotation}
 

--- a/_episodes/02-introduction.md
+++ b/_episodes/02-introduction.md
@@ -277,12 +277,14 @@ the course of the next two days.
 {: .discussion}
 
 [amazon-babt]: http://www.amazon.com/Building-Better-Teacher-Teaching-Everyone/dp/0393081591/
-[amazon-big-picture]: http://www.amazon.com/Big-Picture-Education-Everyones-Business/dp/0871209713/
+[amazon-myths]: http://www.amazon.com/Great-Myths-Brain-Psychology/dp/1118312716/
 [amazon-hlw]: http://www.amazon.com/How-Learning-Works-Research-Based-Jossey-Bass/dp/0470484101/
 [amazon-statistics]: http://www.amazon.com/Teaching-Statistics-Tricks-Andrew-Gelman/dp/0198572247/
+[cs-teaching-tips]: http://csteachingtips.org/
 [learning-theories]: http://www.learning-theories.com/
 [wikipedia-cop]: https://en.wikipedia.org/wiki/Community_of_practice
 [wikipedia-grounded-theory]: https://en.wikipedia.org/wiki/Grounded_theory
+[wikipedia-learning-modes]: https://en.wikipedia.org/wiki/Learning_styles#Learning_modalities
 [wikipedia-peripheral]: https://en.wikipedia.org/wiki/Legitimate_peripheral_participation
 [wikipedia-phonics]: http://en.wikipedia.org/wiki/Phonics
 [wikipedia-situated-learning]: https://en.wikipedia.org/wiki/Situated_learning

--- a/_episodes/03-novice.md
+++ b/_episodes/03-novice.md
@@ -132,7 +132,7 @@ can be used as a model.
 However, there's another, greater challenge to creating mental models.
 
 > It ain't what you don't know that gets you into trouble.
-> It's what you know for sure that just ain't so.  
+> It's what you know for sure that just ain't so.
 > — Mark Twain
 {: .quotation}
 
@@ -384,25 +384,14 @@ and see the topic from their point of view.
 > where they are and what they need to do next.
 {: .discussion}
 
-[amazon-babt]: http://www.amazon.com/Building-Better-Teacher-Teaching-Everyone/dp/0393081591
 [amazon-benner]: http://www.amazon.com/Novice-Expert-Excellence-Clinical-Practice/dp/020100299X/
-[amazon-hlw]: http://www.amazon.com/How-Learning-Works-Research-Based-Jossey-Bass/dp/0470484101/
 [amazon-kr-c]: http://www.amazon.com/Programming-Language-Brian-W-Kernighan/dp/0131103628/
 [amazon-sql-vsg]: http://www.amazon.com/SQL-Visual-QuickStart-Guide-3rd/dp/0321553578/
-[amazon-statistics]: http://www.amazon.com/Teaching-Statistics-Tricks-Andrew-Gelman/dp/0198572247/
 [amazon-thinking-physics]: http://www.amazon.com/Thinking-Physics-Understandable-Practical-Reality/dp/0935218084/r
 [amazon-unix-vsg]: http://www.amazon.com/Unix-Linux-Visual-QuickStart-Guide/dp/0321997549/
 [amazon-upe]: http://www.amazon.com/Unix-Programming-Environment-Prentice-Hall-Software/dp/013937681X/
-[cs-teaching-tips]: http://csteachingtips.org/
-[learning-theories]: http://www.learning-theories.com/
 [peer-instruction-video]: https://www.youtube.com/watch?t=1&v=2LbuoxAy56o
 [swc-shell-novice]: http://swcarpentry.github.io/shell-novice/
-[wikipedia-cop]: https://en.wikipedia.org/wiki/Community_of_practice
 [wikipedia-dreyfus-skill]: https://en.wikipedia.org/wiki/Dreyfus_model_of_skill_acquisition
 [wikipedia-fci]: https://en.wikipedia.org/wiki/Force_Concept_Inventory
-[wikipedia-grounded-theory]: https://en.wikipedia.org/wiki/Grounded_theory
 [wikipedia-peer-instruction]: https://en.wikipedia.org/wiki/Peer_instruction
-[wikipedia-peripheral]: https://en.wikipedia.org/wiki/Legitimate_peripheral_participation
-[wikipedia-phonics]: http://en.wikipedia.org/wiki/Phonics
-[wikipedia-situated-learning]: https://en.wikipedia.org/wiki/Situated_learning
-[wikipedia-whole-language]: http://en.wikipedia.org/wiki/Whole_language

--- a/_episodes/05-performance.md
+++ b/_episodes/05-performance.md
@@ -274,38 +274,38 @@ Sometimes it can be hard to receive feedback, especially negative feedback.
 
 ![Feedback Feelings]({{ site.root }}/fig/deathbulge-jerk.jpg "Comic from http://www.deathbulge.com/comics/155")
 
-Feedback is most effective when the people involved 
-can share ground rules and expectations.  This is especially important 
-when the instructor and/or students have different cultural or 
-domain expectations about feedback.  
+Feedback is most effective when the people involved
+can share ground rules and expectations.  This is especially important
+when the instructor and/or students have different cultural or
+domain expectations about feedback.
 
-Here is a list of different 
+Here is a list of different
 ways that you, as the instructor, can set the stage for receiving feedback
 in a way that helps you improve:
 
 * Initiate feedback.  It's better to ask for feedback than to receive it unwillingly.
 
-* Choose your own questions and ask for specific feedback.  For example: 
-	* "What is one thing I could have done as an instructor to make this lesson more
-  effective?"  
-	* "If you could pick one thing from the lesson to go over again, what 
-	would it be?"
-Specific feedback like this is more useful than a generic "that was great!" or "that 
-was terrible!"  Also, writing your own feedback questions allows you to frame 
-feedback in a way that is helpful to you - the questions above 
-reveal what didn't work in your teaching, but 
-read as professional suggestions rather than personal judgments.  
+* Choose your own questions and ask for specific feedback.  For example:
+    * "What is one thing I could have done as an instructor to make this lesson more
+      effective?"
+    * "If you could pick one thing from the lesson to go over again, what
+      would it be?"
+Specific feedback like this is more useful than a generic "that was great!" or "that
+was terrible!"  Also, writing your own feedback questions allows you to frame
+feedback in a way that is helpful to you - the questions above
+reveal what didn't work in your teaching, but
+read as professional suggestions rather than personal judgments.
 
 * Communicate expectations. If your teaching feedback is taking the form of an
   observation (and you're comfortable enough with the observer), tell
   that person how they can best communicate their feedback to you.
 
-* Balance positive and negative feedback. 
+* Balance positive and negative feedback.
     * Ask for or give "compliment sandwiches" (one positive, one negative, one positive)
     * Ask for both types of feedback
-    
+
 * Use a feedback translator.  Have a fellow
-  instructor (or other trusted person in the room) read over all the feedback and give 
+  instructor (or other trusted person in the room) read over all the feedback and give
   an executive summary.   It can be easier to hear "It sounds like most people
   are following, so you could speed up" than to read several notes all saying, "this is
   too slow" or "this is boring".
@@ -320,7 +320,7 @@ in the room.
 
 Finally, be kind to yourself.
 Mental habits matter: if you're a self-critical person,
-it's okay to remind yourself that: 
+it's okay to remind yourself that:
 
 *   It's not personal.
 *   Look at the positives along with the negatives.

--- a/_episodes/11-load.md
+++ b/_episodes/11-load.md
@@ -204,7 +204,6 @@ and so on.
 
 [cognitive-load-crit]: https://edtechdev.wordpress.com/2009/11/16/cognitive-load-theory-failure/
 [kirschner-paper]: http://www.cogtech.usc.edu/publications/kirschner_Sweller_Clark.pdf
-[memory-test]: http://cat.xula.edu/thinker/memory/working/serial
 [wikipedia-cognitive-load]: https://en.wikipedia.org/wiki/Cognitive_load
 [wikipedia-inquiry]: https://en.wikipedia.org/wiki/Inquiry-based_learning
 [wikipedia-split-attention]: https://en.wikipedia.org/wiki/Split_attention_effect

--- a/_episodes/13-live.md
+++ b/_episodes/13-live.md
@@ -23,7 +23,7 @@ gives general tips for an effective live coding presentation.
 
 ## Why Live Coding?
 
-> Teaching is theater not cinema.  
+> Teaching is theater not cinema.
 > — Neal Davis
 {: .quotation}
 
@@ -215,7 +215,7 @@ something covered earlier.  Novices are going to spend most of their
 time making the same and other mistakes, but how to deal with the is
 left out of most textbooks.
 
-> The typos are the pedagogy  
+> The typos are the pedagogy
 > — [Dana Brunson][brunson-twitter]
 {: .quotation}
 

--- a/_episodes/15-carpentries.md
+++ b/_episodes/15-carpentries.md
@@ -406,9 +406,7 @@ you are very welcome to put your name forward as a candidate.
 [dc-forum]: http://discuss.datacarpentry.org/
 [dc-github]: {{ site.dc_github }}
 [dc-join]: {{ site.dc_site }}/involved/
-[dc-lessons]: {{ site.dc_site }}/lessons/
 [dc-request]: {{ site.dc_site}}/workshops-host/
-[dc-submission-page]: {{ site.dc_site }}/instructor-checkout-exercises/
 [dc-twitter]: https://twitter.com/datacarpentry
 [dc]: {{ site.dc_site }}
 [lessons-learned]: http://f1000research.com/articles/3-62/v2
@@ -418,7 +416,6 @@ you are very welcome to put your name forward as a candidate.
 [swc-blog]: {{ site.swc_site }}/blog/
 [swc-github]: {{ site.swc_github }}/
 [swc-join]: {{ site.swc_site }}/join/
-[swc-lessons]: {{ site.swc_site }}/lessons/
 [swc-operations]: {{ site.swc_site }}/workshops/operations.html
 [swc-request]: {{ site.swc_site}}/workshops/request/
 [swc-steering-committee]: {{ site.swc_site }}/scf/

--- a/_episodes/16-practices.md
+++ b/_episodes/16-practices.md
@@ -227,7 +227,6 @@ Peak rule.
     While it has been criticized for not strongly predicting what's remembered,
     it's always worth trying to end a lesson on a high note.
 
-[brunson-twitter]: https://twitter.com/danabrunson/status/684764295196876800
 [etherpad]: http://etherpad.org
 [wikipedia-dunning-kruger]: https://en.wikipedia.org/wiki/Dunning%E2%80%93Kruger_effect
 [wikipedia-peak-rule]: https://en.wikipedia.org/wiki/Peak%E2%80%93end_rule

--- a/_episodes/19-motivation.md
+++ b/_episodes/19-motivation.md
@@ -475,7 +475,6 @@ are always welcome.
 [reduce-stereotype-threat]: http://www.reducingstereotypethreat.org/reduce.html
 [study-com-stereotype-threat]: http://study.com/academy/lesson/stereotype-threat-definition-examples-theories.html
 [swc-python-v4]: http://swcarpentry.github.io/v4/python/flow.html
-[tpi]: http://www.teachingperspectives.com/tpi/
 [usenix-impostor-syndrome]: https://www.usenix.org/blog/impostor-syndrome-proof-yourself-and-your-community
 [w3c-accessible]: http://www.w3.org/WAI/training/accessible
 [webaim]: http://webaim.org/

--- a/_episodes/20-lessons.md
+++ b/_episodes/20-lessons.md
@@ -440,7 +440,6 @@ large organizations invariably prefer uniformity to productivity.
 
 [amazon-babt]: http://www.amazon.com/Building-Better-Teacher-Teaching-Everyone/dp/0393351084/
 [amazon-csle]: http://www.amazon.com/Creating-Significant-Learning-Experiences-Integrated/dp/1118124251/
-[amazon-myths]: http://www.amazon.com/Great-Myths-Brain-Psychology/dp/1118312716/
 [amazon-slas]: http://www.amazon.com/Seeing-like-State-Certain-Condition/dp/0300078153/
 [amazon-ubd]: http://www.amazon.com/Understanding-Design-Expanded-Grant-Wiggins/dp/0131950843/
 [dc-github]: {{ site.dc_github }}
@@ -448,5 +447,4 @@ large organizations invariably prefer uniformity to productivity.
 [parnas-design]: http://dx.doi.org/10.1109/TSE.1986.6312940
 [swc-github]: {{ site.swc_github }}/
 [wikipedia-bloom]: https://en.wikipedia.org/wiki/Bloom's_taxonomy
-[wikipedia-learning-modes]: https://en.wikipedia.org/wiki/Learning_styles#Learning_modalities
 [wikipedia-tdd]: https://en.wikipedia.org/wiki/Test-driven_development


### PR DESCRIPTION
Some references were missing and some were spurious. I used the script below to check. Perhaps it could be included into `lesson_check.py`.

``` python
import re
from collections import defaultdict, namedtuple
from glob import glob

re_refs = re.compile('\]\[([a-z-]+)\]', flags=re.M)
re_defs = re.compile('^\[([a-z-]+)\]:\s*(.*)', flags=re.M)

fns = glob('_episodes/*.md')

def get_file_refs(fn):
    text = open(fn).read()
    return set(re_refs.findall(text))

def get_file_defs(fn):
    text = open(fn).read()
    return dict(re_defs.findall(text))

file_refs = {fn: get_file_refs(fn) for fn in fns}
file_defs = {fn: get_file_defs(fn) for fn in fns}

Suggestion = namedtuple('Suggestion', ['file', 'url'])
reverse_index = defaultdict(list)
for fn, refs in file_defs.items():
    if not refs: continue
    for key, url in refs.items():
        reverse_index[key].append(Suggestion(fn, url))

for fn in fns:
    defined_keys = set(file_defs[fn].keys())
    missing = file_refs[fn] - defined_keys
    spurious = defined_keys - file_refs[fn]

    if missing or spurious:
        print('\nFound issues with', fn)

    for ref in missing:
        print("Missing reference", ref)
        for suggestion in reverse_index[ref]:
            print('Suggestion for', ref, suggestion.url, 'as defined in', suggestion.file)

    if spurious:
        print("Spurious references", ', '.join(spurious))

```
