### PR TITLE
Fixes and typos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .sass-cache
 _site
 __pycache__
+*.pyc

--- a/_episodes/19-motivation.md
+++ b/_episodes/19-motivation.md
@@ -159,7 +159,7 @@ to make sure they're doing at least a few of these things.
 > learners respond to an instructor's enthusiasm,
 > and instructors need to care about a topic in order to keep teaching it,
 > particularly when they are volunteers.
-{.callout}
+{: .callout}
 
 > ## Why Do You Teach?
 >

--- a/bin/lesson_check.py
+++ b/bin/lesson_check.py
@@ -388,10 +388,6 @@ class CheckBase(object):
 class CheckNonJekyll(CheckBase):
     """Check a file that isn't translated by Jekyll."""
 
-    def __init__(self, args, filename, metadata, metadata_len, text, lines, doc):
-        super(CheckNonJekyll, self).__init__(args, filename, metadata, metadata_len, text, lines, doc)
-
-
     def check_metadata(self):
         self.reporter.check(self.metadata is None,
                             self.filename,
@@ -408,9 +404,6 @@ class CheckIndex(CheckBase):
 
 class CheckEpisode(CheckBase):
     """Check an episode page."""
-
-    def __init__(self, args, filename, metadata, metadata_len, text, lines, doc):
-        super(CheckEpisode, self).__init__(args, filename, metadata, metadata_len, text, lines, doc)
 
     def check_metadata(self):
         super(CheckEpisode, self).check_metadata()

--- a/bin/util.py
+++ b/bin/util.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 import sys
 import os
 import json


### PR DESCRIPTION
Here are some trivial fixes.

* Add *.pyc to `.gitignore`
* Fix typo `{.callout}` -> `{: .callout}`
* Add missing future statement in `bin/util.py`
* Remove some unnecessary code in `bin/lesson_check.py`

I apologise for the single PR but they are fairly trivial and can be cherry-picked independently.