### PR TITLE
Checkout: add teaching demo lesson/segment examples

### DIFF
--- a/_extras/checkout.md
+++ b/_extras/checkout.md
@@ -238,6 +238,7 @@ For your teaching demonstration, you will teach a short segment from your chosen
 We will pick the segment of the lesson(s) you are to teach
 on the day of the demonstration,
 so you must be prepared to teach any part of your chosen lesson(s).
+For example, you may choose the [Unix Shell lesson]({{site.swc_pages}}/shell-novice/) and be asked to teach starting from the [loops segment]({{site.swc_pages}}/shell-novice/05-loop/). Or you may choose the [Data Carpentry R for Genomics]({{site.dc_site}}/R-genomics/) lesson and be asked to teach the [introduction to data frame]({{site.dc_site}}/R-genomics/03-data-frames.html) segment.
 
 For your demonstration(s),
 you will screen-share


### PR DESCRIPTION
Based on some feedback from a instructor trainee, there is a danger of confusion when trainees need to choose a lesson to teach from. For SWC all is well, what is a lesson and an episode is clear from the webpage. For DataCarpentry, however, the situation is a bit more blurry. http://www.datacarpentry.org/lessons/ lists workshops which each have lessons. But, for example, the R-genomics lesson http://www.datacarpentry.org/R-genomics/ has its episodes called `lesson 00`, `lesson 01` etc. Perhaps we need to ask DC to adjust that. 

At any rate, this PR adds an example lesson and segment that trainees may be asked to demonstrate for both SWC and DC.