### PR TITLE
Add reminder about closed captioning

### DIFF
--- a/_episodes/13-live.md
+++ b/_episodes/13-live.md
@@ -90,6 +90,8 @@ another.
 > and it is assumed learners are familiar with how to use a variable,
 > the `head `command and the content of the `basilisk.dat unicorn.dat`
 > files.
+>
+> Note: sometime sounds in the room can be poor. Turning on closed captioning by pressing the cc button will improve the accessibility of these videos. 
 {: .challenge}
 
 ## Live Coding Top 10


### PR DESCRIPTION
Fixes issue https://github.com/swcarpentry/instructor-training/issues/414, at least in the main lesson page.