### PR TITLE
changed default behavior for how challenges show

### DIFF
--- a/assets/js/lesson.js
+++ b/assets/js/lesson.js
@@ -3,7 +3,7 @@ $("table").addClass("table table-striped");
 
 
 // Handle foldable challenges and solutions (on click and at start).
-$(".challenge,.discussion,.solution").click(function(event) {
+$(".discussion,.solution").click(function(event) {
     var trigger = $(event.target).has(".fold-unfold").size() > 0
                || $(event.target).filter(".fold-unfold").size() > 0;
     if (trigger) {
@@ -12,7 +12,7 @@ $(".challenge,.discussion,.solution").click(function(event) {
         event.stopPropagation();
     }
 });
-$(".challenge,.discussion,.solution").each(function() {
+$(".discussion,.solution").each(function() {
     $(">*:not(h2)", this).toggle();
     var h2 = $("h2:first", this);
     h2.append("<span class='fold-unfold glyphicon glyphicon-collapse-down'></span>");


### PR DESCRIPTION
Addresses https://github.com/swcarpentry/instructor-training/issues/435

Makes it so that challenge text shows by default, rather than needing to be clicked to appear.

Removes the reference to '.challenge' in assets/js/lesson.js