### PR TITLE
Fink not Fisk typo

### DIFF
--- a/_episodes/19-lessons.md
+++ b/_episodes/19-lessons.md
@@ -137,7 +137,7 @@ in learning objectives written for each level.
   <tr>
     <th>Bloom's taxonomy</th>
     <th>Facets of understanding (Wiggins & McTighe)</th>
-    <th>Taxonomy of significant learning (Fisk)</th>
+    <th>Taxonomy of significant learning (Fink)</th>
     <th>Typical learning objective verbs</th>
   </tr>
   <tr>


### PR DESCRIPTION
The author of Taxonomy of significant learning is Fink not Fisk

This lesson is currently being prepared for publication and is under development at https://github.com/ErinBecker/instructor-training-reorg/. Please submit any issues or PRs to that repo (not here).
