### PR TITLE
Fixed typing error

### DIFF
--- a/_episodes/01-welcome.md
+++ b/_episodes/01-welcome.md
@@ -19,7 +19,7 @@ keypoints:
 
 ## Code of Conduct
 
-To make clear what is expected, everyone participating in Software Carpentry and Software Carpentry activities is required
+To make clear what is expected, everyone participating in Software Carpentry and Data Carpentry activities is required
 to conform to our Code of Conduct. This Code of Conduct applies to all spaces managed by Software Carpentry
 and Data Carpentry including, but not limited to workshops, email lists, online forums and on GitHub. Please review
 [the Code of Conduct](https://software-carpentry.org/conduct/) so you are familiar with it.


### PR DESCRIPTION
Software Carpentry were duplicated. Might also make sense to  just say "Carpentry activities" after the merger


